### PR TITLE
Optimized

### DIFF
--- a/src/test/java/TestConsistHashWithComp.java
+++ b/src/test/java/TestConsistHashWithComp.java
@@ -38,9 +38,10 @@ public class TestConsistHashWithComp {
 
         long start = System.currentTimeMillis();
 
+        Thread [] threads= new Thread[100];
         for (int i = 0; i < 100; i++) {
             final String name = "thread" + i;
-            Thread t = new Thread(new Runnable() {
+            threads[i] = new Thread(new Runnable() {
                 @Override
                 public void run() {
                     for (int h = 0; h < 100000; h++) {
@@ -50,10 +51,12 @@ public class TestConsistHashWithComp {
                     testConsistHashWithComp.print();
                 }
             }, name);
-            t.start();
+            threads[i].start();
         }
         System.out.println(System.currentTimeMillis() - start);
-        Thread.sleep(1000 * 20);
+        for(Thread t: threads)
+            t.join();
+//        Thread.sleep(1000 * 20);
         testConsistHashWithComp.print();
     }
 

--- a/src/test/java/TestConsistHashWithComp.java
+++ b/src/test/java/TestConsistHashWithComp.java
@@ -60,12 +60,14 @@ public class TestConsistHashWithComp {
         testConsistHashWithComp.print();
     }
 
-    public synchronized void send(Node node) {
-        Long count = stat.get(node.getIp());
-        if (count == null) {
-            stat.put(node.getIp(), 1L);
-        } else {
-            stat.put(node.getIp(), count + 1);
+    public void send(Node node) {
+        synchronized(node) {
+            Long count = stat.get(node.getIp());
+            if (count == null) {
+                stat.put(node.getIp(), 1L);
+            } else {
+                stat.put(node.getIp(), count + 1);
+            }
         }
     }
 


### PR DESCRIPTION
The send method of the class is implemented as synchronized and as a result only one thread can access the method at a given time.
However, what is needed is to ensure here that the get and put operation for the same node needs to be done atomically.
This can be achieved easily by synchronizing on the node which would essentially use separate locks for separate nodes.
Thus it would allow multiple threads to run parallelly on different nodes. The solution reduces the lock contention
on current implementation and improves performance significantly.